### PR TITLE
Corrigindo os metodos de Login e Redefinição de CPF

### DIFF
--- a/auth/auth.py
+++ b/auth/auth.py
@@ -21,7 +21,7 @@ class OAuth2:
             exp = datetime.utcnow() + timedelta(minutes=expires_in)
             
             payload = {
-                'sub': user.email,
+                'sub': user.cpf,
                 'exp': exp
             }
 

--- a/repository/usuarios.py
+++ b/repository/usuarios.py
@@ -28,7 +28,7 @@ class UserRepository:
     @staticmethod
     def update_user_password(db: Session, user: ResetPasswordRequest):
 
-        db_user = UserRepository.get_user_by_email(db, email=user.email)
+        db_user = UserRepository.get_user_by_cpf(db, cpf=user.cpf)
 
         try:
             db_user.senha = user.nova_senha

--- a/routers/usuarios.py
+++ b/routers/usuarios.py
@@ -23,7 +23,7 @@ async def create_user(user: UserCreate, db: Session = Depends(get_db)):
 @router.post("/login")
 async def login_user(request_form_user: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
     user = LoginRequest(
-        email=request_form_user.username,
+        cpf=request_form_user.username,
         senha=request_form_user.password
     )
 

--- a/schemas/usuarios.py
+++ b/schemas/usuarios.py
@@ -18,11 +18,11 @@ class UserCreate(UserBase):
     senha: str
 
 class LoginRequest(BaseModel):
-    email: str
+    cpf: str
     senha: str
     
 class ResetPasswordRequest(BaseModel):
-    email: str
+    cpf: str
     nova_senha: str
 
 class UserOut(UserBase):

--- a/services/usuarios.py
+++ b/services/usuarios.py
@@ -72,18 +72,18 @@ def create_user_service(db: Session, user: UserCreate):
 
         
 def login_user_service(db: Session, user: LoginRequest):
-    user_db = UserRepository.get_user_by_email(db=db, email=user.email)
+    user_db = UserRepository.get_user_by_cpf(db=db, cpf=user.cpf)
 
     if not user_db:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Usuário ou senha incorreta!"
+            detail="CPF ou senha incorreta!"
         )
     
     if not AuthHandler.verify_password(user.senha, user_db.senha):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Usuário ou senha incorreta!"
+            detail="CPF ou senha incorreta!"
         )
     
     return OAuth2.user_login(user_db)
@@ -91,7 +91,7 @@ def login_user_service(db: Session, user: LoginRequest):
 
 def reset_password_service(db: Session, user: ResetPasswordRequest):
 
-    user_db = UserRepository.get_user_by_email(db=db, email=user.email)
+    user_db = UserRepository.get_user_by_cpf(db=db, cpf=user.cpf)
                                                
     if not user_db:
         raise HTTPException(


### PR DESCRIPTION
Conforme a documentação escrita, o login deve ser realizado com CPF e SENHA. No primeiro momento estava sendo realizado com EMAIL e SENHA. Com essa alteração, o sistema ficará de acordo com a documentação.